### PR TITLE
_reconstruct line fix pandas compatibility

### DIFF
--- a/q2_sidle/_reconstruct.py
+++ b/q2_sidle/_reconstruct.py
@@ -509,7 +509,7 @@ def _solve_iterative_noisy(align_mat, table, seq_summary, tolerance=1e-7,
     align_asvs = align.index.values
 
     recon = []
-    for sample, col_ in table.iteritems():
+    for sample, col_ in table.items():
         filt_align = align.loc[col_ > 0].values
         abund = col_[col_ > 0].values
         sub_seqs = copy.copy(align_seqs)[(filt_align > 0).any(axis=0)]


### PR DESCRIPTION
Hi !
First of all thanks for writting sidle, I'm just starting using it.

There was a small issue in _reconstruct.py since the qiime2 install uses pandas > 2.

```
Traceback (most recent call last):
  File "/home/nicolas/miniforge3/envs/qiime2-amplicon-2024.10/lib/python3.10/site-packages/q2cli/commands.py", line 530, in __call__
    results = self._execute_action(
  File "/home/nicolas/miniforge3/envs/qiime2-amplicon-2024.10/lib/python3.10/site-packages/q2cli/commands.py", line 602, in _execute_action
    results = action(**arguments)
  File "<decorator-gen-683>", line 2, in reconstruct_counts
  File "/home/nicolas/miniforge3/envs/qiime2-amplicon-2024.10/lib/python3.10/site-packages/qiime2/sdk/action.py", line 299, in bound_callable
    outputs = self._callable_executor_(
  File "/home/nicolas/miniforge3/envs/qiime2-amplicon-2024.10/lib/python3.10/site-packages/qiime2/sdk/action.py", line 570, in _callable_executor_
    output_views = self._callable(**view_args)
  File "/home/nicolas/miniforge3/envs/qiime2-amplicon-2024.10/lib/python3.10/site-packages/q2_sidle/_reconstruct.py", line 158, in reconstruct_counts
    rel_abund = _solve_iterative_noisy(align_mat=align_mat,
  File "/home/nicolas/miniforge3/envs/qiime2-amplicon-2024.10/lib/python3.10/site-packages/q2_sidle/_reconstruct.py", line 512, in _solve_iterative_noisy
    for sample, col_ in table.iteritems():
  File "/home/nicolas/miniforge3/envs/qiime2-amplicon-2024.10/lib/python3.10/site-packages/pandas/core/generic.py", line 6299, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'iteritems'. Did you mean: 'isetitem'?
```


I just did this small fork to fix it for myself but I figured it could be useful, maybe I'm going to do some more changes in the upcomming days.
Best !
Nicolas